### PR TITLE
Link to our new API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI (mono)](https://github.com/twingly/twingly-search-api-dotnet/workflows/CI%20(mono)/badge.svg?branch=master)](https://github.com/twingly/twingly-search-api-dotnet/actions?query=workflow%3A%22CI+%28mono%29%22)
 
 
-.NET client for Twingly Search API (previously known as Twingly Analytics API). Twingly is a blog search service that provides [a searchable API](https://developer.twingly.com/resources/search/).
+.NET client for Twingly Search API (previously known as Twingly Analytics API). Twingly is a blog search service that provides [a searchable API](https://app.twingly.com/blog_search?tab=documentation).
 
 ## Installation
 

--- a/Twingly.Search.Client/Domain/Language.cs
+++ b/Twingly.Search.Client/Domain/Language.cs
@@ -3,9 +3,9 @@
 namespace Twingly.Search.Client.Domain
 {
     /// <summary>
-    /// Enumerates all the languages supported by Twingly. 
+    /// Enumerates all the languages supported by Twingly.
     /// </summary>
-    /// <see cref="https://developer.twingly.com/resources/search-language/#supported-languages"/>
+    /// <see cref="https://app.twingly.com/blog_search?tab=documentation"/>
     public enum Language
     {
         /// <summary>

--- a/Twingly.Search.Client/Domain/Post.cs
+++ b/Twingly.Search.Client/Domain/Post.cs
@@ -85,14 +85,14 @@ namespace Twingly.Search.Client.Domain
 
         /// <summary>
         /// Indicates the authority of the blog, at time of indexing.
-        /// <see cref="https://developer.twingly.com/resources/ranking#authority"/>
+        /// <see cref="https://app.twingly.com/blog_search?tab=documentation"/>
         /// </summary>
         [XmlElement("authority")]
         public double Authority { get; set; }
 
         /// <summary>
         /// Indicates how influential the blog is, at time of indexing,
-        /// <see cref="https://developer.twingly.com/resources/ranking#blogrank"/>.
+        /// <see cref="https://app.twingly.com/blog_search?tab=documentation"/>.
         /// </summary>
         [XmlElement("blogRank")]
         public double BlogRank { get; set; }

--- a/Twingly.Search.Client/Domain/TwinglyConfiguration.cs
+++ b/Twingly.Search.Client/Domain/TwinglyConfiguration.cs
@@ -12,7 +12,7 @@ namespace Twingly.Search.Client.Domain
         /// and the default timeout.
         /// </summary>
         /// <param name="apiKey">
-        /// Twingly Search API key. See <see cref="https://developer.twingly.com/resources/search/"/> for more details.
+        /// Twingly Search API key. See <see cref="https://app.twingly.com/blog_search?tab=documentation"/> for more details.
         /// </param>
         public TwinglyConfiguration(string apiKey) : this(apiKey, Constants.DefaultTimeoutInMilliseconds)
         {
@@ -24,7 +24,7 @@ namespace Twingly.Search.Client.Domain
         /// and <paramref name="requestTimeoutMilliseconds"/>.
         /// </summary>
         /// <param name="apiKey">
-        /// Twingly Search API key. See <see cref="https://developer.twingly.com/resources/search/"/> for more details.
+        /// Twingly Search API key. See <see cref="https://app.twingly.com/blog_search?tab=documentation"/> for more details.
         /// </param>
         /// <param name="requestTimeoutMilliseconds">
         /// The configured request timeout in milliseconds.

--- a/Twingly.Search.Client/QueryBuilder.cs
+++ b/Twingly.Search.Client/QueryBuilder.cs
@@ -37,7 +37,7 @@ namespace Twingly.Search.Client
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the specified search query is a null or empty string.
         /// </exception>
-        /// <see cref="https://developer.twingly.com/resources/search-language/"/>
+        /// <see cref="https://app.twingly.com/blog_search?tab=documentation"/>
         public QueryBuilder SearchQuery(string query)
         {
             _internalQuery.SearchQuery = query;

--- a/Twingly.Search.Samples/AdvancedQueryLanguageExample.cs
+++ b/Twingly.Search.Samples/AdvancedQueryLanguageExample.cs
@@ -10,7 +10,7 @@ namespace Twingly.Search.Samples
     /// such as logical operators and sorting.
     /// </summary>
     /// <remarks>
-    /// Learn more about the search language - https://developer.twingly.com/resources/search-language/
+    /// Learn more about the search language - https://app.twingly.com/blog_search?tab=documentation
     /// </remarks>
     public class AdvancedQueryLanguageExample
     {

--- a/Twingly.Search.Samples/PageOverBlogPostsExample.cs
+++ b/Twingly.Search.Samples/PageOverBlogPostsExample.cs
@@ -9,7 +9,7 @@ namespace Twingly.Search.Samples
     /// <summary>
     /// Showcases how to retrieve all matching posts
     /// in a paged manner. Paging is done via the sliding window technique.
-    /// See https://developer.twingly.com/resources/search/#pagination for more details.
+    /// See https://app.twingly.com/blog_search?tab=documentation for more details.
     /// </summary>
     public static class PageOverBlogPostsExample
     {


### PR DESCRIPTION
As the old site, developer.twingly.com, has been shut down. The documentation for all of our APIs are now available (behind login) at https://app.twingly.com instead.